### PR TITLE
Fix blocking on stdin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,6 +98,62 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
 
 [[package]]
+name = "crossbeam"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33480d6946193aa8033910124896ca395333cae7e2d1113d1fef6c3272217df2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df0346b5d5e76ac2fe4e327c5fd1118d6be7c51dfb18f9b7922923f287471e35"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
+
+[[package]]
 name = "eyre"
 version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -154,6 +210,7 @@ name = "runner"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "crossbeam",
  "eyre",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 clap = { version = "4.5.16", features = ["derive", "env"] }
+crossbeam = "0.8.4"
 eyre = "0.6.12"
 
 [lints.clippy]

--- a/src/flat_map_err.rs
+++ b/src/flat_map_err.rs
@@ -1,0 +1,50 @@
+/// A trait for `Result` that allows chaining a function that returns a `Result` to the error type.
+///
+/// # Examples
+/// One use case is if the ok type, `T` has a default value, and the error type, `E` may take
+/// multiple values that may be ignored, then this trait can be used to map the error type to the
+/// default value of `T` for the errors that can be ignored.
+pub(crate) trait FlatMapErr<T, D, E> {
+    fn flat_map_err<F>(self, f: F) -> Result<T, E>
+    where
+        F: FnOnce(D) -> Result<T, E>;
+}
+
+impl<T, D, E> FlatMapErr<T, D, E> for Result<T, D> {
+    fn flat_map_err<F>(self, f: F) -> Result<T, E>
+    where
+        F: FnOnce(D) -> Result<T, E>,
+    {
+        match self.map_err(f) {
+            Ok(t) | Err(Ok(t)) => Ok(t),
+            Err(Err(e)) => Err(e),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    #[test]
+    fn flat_map_err() {
+        use super::FlatMapErr;
+
+        #[derive(Debug, PartialEq, Eq)]
+        enum Error {
+            IgnorableError,
+            GraveError,
+        }
+
+        let ignore = |e| match e {
+            Error::IgnorableError => Ok(()),
+            Error::GraveError => Err(e),
+        };
+
+        let success = Ok(());
+        let ignorable_error = Err(Error::IgnorableError);
+        let grave_error = Err(Error::GraveError);
+
+        assert_eq!(success.flat_map_err(ignore), Ok(()));
+        assert_eq!(ignorable_error.flat_map_err(ignore), Ok(()));
+        assert_eq!(grave_error.flat_map_err(ignore), Err(Error::GraveError));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+mod flat_map_err;
+
 use eyre::{eyre, Result};
 use std::{
     fs::File,


### PR DESCRIPTION
If the child process exits before the stdin receives EOF, the tee thread for stdin will block indefinitely. This change will cancel that tee thread when the child process exits.
This is not needed for stdout and stderr because the child process will close those file descriptors when it exits.
But for stdin, the file descriptors is the parent's stdin, so it won't be closed when the child exits.